### PR TITLE
Add macOS Keychain cookie decryption and Chrome support to local CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,34 @@ Install as the following directions supports automatic updates when new versions
 - [Edge Addons](https://microsoftedge.microsoft.com/addons/detail/internet-archive-download/cnpoedgimjaecinmgfnfhfmcpcngeeje)
 - [Mozilla Addons (Firefox)](https://addons.mozilla.org/en-US/firefox/addon/internet_archive_downloader/)
 
+## Local runner
+A local command-line runner is included for `archive.org/details/...` URLs. This is useful when the browser extension cannot be installed.
+
+On Windows:
+
+```powershell
+.\iad.cmd https://archive.org/details/victorygirls00unit
+```
+
+Useful options:
+
+```powershell
+.\iad.cmd https://archive.org/details/victorygirls00unit --start 1 --end 10 --scale 2
+.\iad.cmd https://archive.org/details/victorygirls00unit --zip --output .\book.zip
+.\iad.cmd https://archive.org/details/some_borrowed_book --cookie-file .\cookies.txt
+.\iad.cmd https://archive.org/details/some_borrowed_book --cookies-from-brave
+.\iad.cmd https://archive.org/details/some_borrowed_book --cookies-from-edge
+.\iad.cmd https://archive.org/details/some_borrowed_book --cookies-from-brave --output .\book.pdf
+```
+
+Notes:
+* The local runner currently supports `archive.org` detail pages only.
+* For borrowed books, pass your authenticated browser cookies with `--cookie` or `--cookie-file`.
+* `--cookies-from-brave` and `--cookies-from-edge` launch the selected browser with its existing profile and use that live browser session for protected page requests.
+* Close the selected browser first, then run the command. If the opened browser window is not actively borrowing the book yet, borrow it there and leave it open while the terminal continues.
+* The downloader closes the browser session it launched when the download finishes.
+* Output defaults to PDF. Use `--zip` to save page images instead.
+
 ## Configuration
 - For Firefox, permissions of access to related websites must be granted in the "Permissions" tab within the extension detail page.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Install as the following directions supports automatic updates when new versions
 - [Mozilla Addons (Firefox)](https://addons.mozilla.org/en-US/firefox/addon/internet_archive_downloader/)
 
 ## Local runner
-A local command-line runner is included for `archive.org/details/...` URLs. This is useful when the browser extension cannot be installed.
+A local command-line runner is included for `archive.org/details/...` URLs. This is useful when the browser extension cannot be installed. Requires Node.js 22+.
 
 On Windows:
 
@@ -49,7 +49,13 @@ On Windows:
 .\iad.cmd https://archive.org/details/victorygirls00unit
 ```
 
-Useful options:
+On macOS / Linux:
+
+```bash
+./iad.sh https://archive.org/details/victorygirls00unit
+```
+
+Useful options (PowerShell shown; substitute `./iad.sh` on macOS/Linux):
 
 ```powershell
 .\iad.cmd https://archive.org/details/victorygirls00unit --start 1 --end 10 --scale 2
@@ -57,13 +63,14 @@ Useful options:
 .\iad.cmd https://archive.org/details/some_borrowed_book --cookie-file .\cookies.txt
 .\iad.cmd https://archive.org/details/some_borrowed_book --cookies-from-brave
 .\iad.cmd https://archive.org/details/some_borrowed_book --cookies-from-edge
-.\iad.cmd https://archive.org/details/some_borrowed_book --cookies-from-brave --output .\book.pdf
+.\iad.cmd https://archive.org/details/some_borrowed_book --cookies-from-chrome
+.\iad.cmd https://archive.org/details/some_borrowed_book --cookies-from-chrome --output .\book.pdf
 ```
 
 Notes:
 * The local runner currently supports `archive.org` detail pages only.
 * For borrowed books, pass your authenticated browser cookies with `--cookie` or `--cookie-file`.
-* `--cookies-from-brave` and `--cookies-from-edge` launch the selected browser with its existing profile and use that live browser session for protected page requests.
+* `--cookies-from-brave`, `--cookies-from-edge`, and `--cookies-from-chrome` launch the selected browser with its existing profile and use that live browser session for protected page requests. Supported on Windows and macOS.
 * Close the selected browser first, then run the command. If the opened browser window is not actively borrowing the book yet, borrow it there and leave it open while the terminal continues.
 * The downloader closes the browser session it launched when the download finishes.
 * Output defaults to PDF. Use `--zip` to save page images instead.

--- a/cli/archive-cli.mjs
+++ b/cli/archive-cli.mjs
@@ -1,0 +1,759 @@
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { spawn, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import PDFDocument from '../core/js/pdf/document.js';
+import ZIPDocument from '../core/js/zip/document.js';
+import ImageDecoder from '../core/js/utils/image_decoder.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const defaultUserAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36';
+const defaultConcurrency = 6;
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.help || !options.url) {
+    printHelp();
+    process.exit(options.help ? 0 : 1);
+  }
+
+  let browserSession = null;
+  let writer = null;
+  try {
+    const detailUrl = normalizeDetailUrl(options.url);
+    browserSession = getRequestedBrowserSession(options)
+      ? await loadBrowserArchiveSession(getRequestedBrowserSession(options), detailUrl, options.braveProfile ?? options.browserProfile ?? 'Default')
+      : null;
+    const headers = await buildHeaders(options, browserSession);
+
+    console.log(`Loading ${detailUrl}`);
+    let br = browserSession?.br;
+    if (!br) {
+      const detailHtml = await fetchText(detailUrl, headers);
+      const jsiaUrl = extractJsiaUrl(detailHtml);
+      const payload = JSON.parse(await fetchText(jsiaUrl, headers));
+      br = payload?.data?.brOptions;
+    }
+
+    if (!br?.bookId || !Array.isArray(br.data)) {
+      throw new Error('Could not extract BookReader metadata from the page.');
+    }
+
+    const pages = br.data.flat();
+    if (pages.length === 0) {
+      throw new Error('The item did not expose any page images.');
+    }
+    assertFullBookReaderAccess(br, pages);
+
+    const pageCount = pages.length;
+    const start = clampInt(options.start ?? 1, 1, pageCount);
+    const end = clampInt(options.end ?? pageCount, start, pageCount);
+    const scale = clampInt(options.scale ?? 1, 1, 32);
+    const concurrency = clampInt(options.concurrency ?? defaultConcurrency, 1, 32);
+    const format = options.zip ? 'zip' : 'pdf';
+    const outputPath = path.resolve(options.output ?? buildDefaultName(br.bookId, scale, start, end, pageCount, format));
+
+    console.log(`Book: ${br.bookTitle ?? br.bookId}`);
+    console.log(`Pages: ${start}-${end} of ${pageCount}`);
+    console.log(`Format: ${format.toUpperCase()}  Scale: ${scale}  Workers: ${concurrency}`);
+    console.log(`Output: ${outputPath}`);
+
+    writer = new FileWriter(outputPath);
+    const doc = await createDocument(writer, format, br, end - start + 1);
+    const jobs = [];
+
+    for (let pageNumber = start; pageNumber <= end; pageNumber++) {
+      const sourceIndex = pageNumber - 1;
+      const selectedIndex = pageNumber - start;
+      const page = pages[sourceIndex];
+      jobs.push({
+        sourceIndex,
+        selectedIndex,
+        pageNumber,
+        page,
+      });
+    }
+
+    let completed = 0;
+    await runPool(jobs, concurrency, async job => {
+      const buffer = await fetchArchivePage(job.page, scale, headers, browserSession);
+      const view = new DataView(buffer);
+
+      if (format === 'zip') {
+        const name = `${sanitizeName(br.bookId)}_${String(job.pageNumber).padStart(4, '0')}`;
+        doc.image({ view, name });
+      } else {
+        doc.image(view, null, {
+          pageindex: job.selectedIndex,
+          x: 0,
+          y: 0,
+          width: Math.ceil(job.page.width / scale),
+          height: Math.ceil(job.page.height / scale),
+        });
+      }
+
+      completed += 1;
+      console.log(`[${completed}/${jobs.length}] page ${job.pageNumber}`);
+    });
+
+    doc.end();
+    await writer.close();
+  } catch (error) {
+    await writer?.abort();
+    throw error;
+  } finally {
+    await browserSession?.close();
+  }
+
+  console.log('Done');
+}
+
+function parseArgs(argv) {
+  const options = {};
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    switch (arg) {
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      case '--zip':
+        options.zip = true;
+        break;
+      case '--pdf':
+        options.zip = false;
+        break;
+      case '--url':
+        options.url = argv[++i];
+        break;
+      case '--output':
+      case '-o':
+        options.output = argv[++i];
+        break;
+      case '--start':
+        options.start = parseNumberArg(arg, argv[++i]);
+        break;
+      case '--end':
+        options.end = parseNumberArg(arg, argv[++i]);
+        break;
+      case '--scale':
+        options.scale = parseNumberArg(arg, argv[++i]);
+        break;
+      case '--concurrency':
+      case '--workers':
+        options.concurrency = parseNumberArg(arg, argv[++i]);
+        break;
+      case '--cookie':
+        options.cookie = argv[++i];
+        break;
+      case '--cookie-file':
+        options.cookieFile = argv[++i];
+        break;
+      case '--cookies-from-brave':
+        options.cookiesFromBrave = true;
+        break;
+      case '--cookies-from-edge':
+        options.cookiesFromEdge = true;
+        break;
+      case '--brave-profile':
+        options.braveProfile = argv[++i];
+        break;
+      case '--browser-profile':
+        options.browserProfile = argv[++i];
+        break;
+      default:
+        if (!arg.startsWith('-') && !options.url) {
+          options.url = arg;
+        } else {
+          throw new Error(`Unknown argument: ${arg}`);
+        }
+        break;
+    }
+  }
+
+  return options;
+}
+
+function parseNumberArg(flag, value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Expected a number after ${flag}`);
+  }
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  iad.cmd <archive.org/details/...> [options]
+  node cli/archive-cli.mjs <archive.org/details/...> [options]
+
+Options:
+  --pdf                 Write a PDF file (default)
+  --zip                 Write a ZIP of page images
+  --start <n>           First page number (1-based)
+  --end <n>             Last page number
+  --scale <n>           Archive.org scale divisor, e.g. 1, 2, 4
+  --workers <n>         Parallel page fetches (default: 6)
+  --output, -o <path>   Output path
+  --cookie <value>      Raw Cookie header for borrowed books
+  --cookie-file <path>  Read Cookie header value from a file
+  --cookies-from-brave  Read archive.org cookies from your Brave profile
+  --cookies-from-edge   Read archive.org cookies from your Edge profile
+  --brave-profile <p>   Brave profile name, default: Default
+  --browser-profile <p> Browser profile name, default: Default
+  --help, -h            Show this help
+
+Examples:
+  iad.cmd https://archive.org/details/victorygirls00unit
+  iad.cmd https://archive.org/details/victorygirls00unit --start 1 --end 10 --scale 2
+  iad.cmd https://archive.org/details/some_borrowed_book --cookie-file cookies.txt`);
+}
+
+async function buildHeaders(options, browserSession = null) {
+  const headers = {
+    'user-agent': defaultUserAgent,
+    accept: '*/*',
+  };
+
+  let cookie = options.cookie;
+  if (!cookie && options.cookieFile) {
+    cookie = (await fsp.readFile(path.resolve(options.cookieFile), 'utf8')).trim();
+  }
+  if (!cookie && options.cookiesFromBrave) {
+    cookie = browserSession?.cookieHeader ?? null;
+  }
+  if (!cookie && options.cookiesFromEdge) {
+    cookie = browserSession?.cookieHeader ?? null;
+  }
+  if (cookie) {
+    headers.cookie = cookie;
+  }
+
+  return headers;
+}
+
+function assertFullBookReaderAccess(br, pages) {
+  const previewPages = pages.filter(page => typeof page.uri === 'string' && page.uri.includes('BookReaderPreview.php'));
+  const unviewablePages = pages.filter(page => page.viewable === false);
+
+  if (br.protected && (previewPages.length > 0 || unviewablePages.length > 0)) {
+    throw new Error(
+      'Archive.org is returning preview-only BookReader data for this session. ' +
+      'Open the item in the same browser/profile, borrow it there, then rerun the downloader with the matching browser cookie option.'
+    );
+  }
+}
+
+function getRequestedBrowserSession(options) {
+  if (options.cookiesFromBrave && options.cookiesFromEdge) {
+    throw new Error('Choose only one browser cookie source.');
+  }
+  if (options.cookiesFromBrave) {
+    return 'brave';
+  }
+  if (options.cookiesFromEdge) {
+    return 'edge';
+  }
+  return null;
+}
+
+async function loadBrowserArchiveSession(browserName, detailUrl, profileName) {
+  const browser = findBrowserInstall(browserName);
+  if (isProcessRunning(browser.processName)) {
+    throw new Error(`Could not read cookies from ${browser.displayName}. Close ${browser.displayName} first, then retry.`);
+  }
+
+  const debugPort = browser.debugPort;
+  const args = [
+    `--remote-debugging-port=${debugPort}`,
+    `--user-data-dir=${browser.userDataDir}`,
+    `--profile-directory=${profileName}`,
+    '--no-first-run',
+    '--no-default-browser-check',
+    detailUrl,
+  ];
+  const child = spawn(browser.exePath, args, {
+    detached: false,
+    stdio: 'ignore',
+    windowsHide: true,
+  });
+  let pageCdp = null;
+  let browserCdp = null;
+
+  try {
+    const version = await waitForJson(`http://127.0.0.1:${debugPort}/json/version`, 15000);
+    const pageTarget = await waitForPageTarget(debugPort, detailUrl, 15000);
+    pageCdp = createCdpClient(pageTarget.webSocketDebuggerUrl);
+    browserCdp = createCdpClient(version.webSocketDebuggerUrl);
+
+    await pageCdp.connect();
+    await browserCdp.connect();
+    await pageCdp.send('Runtime.enable');
+
+    const brJson = await waitForWindowBr(pageCdp, 180000);
+    const cookiesResult = await browserCdp.send('Storage.getCookies');
+    const header = buildCookieHeader(cookiesResult.cookies ?? [], 'archive.org');
+    const br = JSON.parse(brJson);
+
+    if (!header) {
+      throw new Error(`No archive.org cookies were found in ${browser.displayName} profile "${profileName}".`);
+    }
+    if (!br?.bookId || !Array.isArray(br.data)) {
+      throw new Error(`Could not read authenticated BookReader data from ${browser.displayName}.`);
+    }
+
+    return {
+      cookieHeader: header,
+      br,
+      fetchResource: url => fetchResourceInBrowser(pageCdp, url),
+      async close() {
+        try {
+          await browserCdp.send('Browser.close');
+        } catch (_) {
+          child.kill();
+        } finally {
+          pageCdp.close();
+          browserCdp.close();
+        }
+      },
+    };
+  } catch (error) {
+    pageCdp?.close();
+    browserCdp?.close();
+    child.kill();
+    throw error;
+  }
+}
+
+function isProcessRunning(imageName) {
+  const result = spawnSync('tasklist', ['/FI', `IMAGENAME eq ${imageName}`], {
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  return result.status === 0 && result.stdout.toLowerCase().includes(imageName.toLowerCase());
+}
+
+function findBrowserInstall(browserName) {
+  const localAppData = process.env.LOCALAPPDATA;
+  const programFiles = process.env['PROGRAMFILES'];
+  const programFilesX86 = process.env['PROGRAMFILES(X86)'];
+  const configs = {
+    brave: {
+      displayName: 'Brave',
+      processName: 'brave.exe',
+      exeName: 'brave.exe',
+      debugPort: 9223,
+      installParts: ['BraveSoftware', 'Brave-Browser', 'Application'],
+      userDataParts: ['BraveSoftware', 'Brave-Browser', 'User Data'],
+    },
+    edge: {
+      displayName: 'Edge',
+      processName: 'msedge.exe',
+      exeName: 'msedge.exe',
+      debugPort: 9224,
+      installParts: ['Microsoft', 'Edge', 'Application'],
+      userDataParts: ['Microsoft', 'Edge', 'User Data'],
+    },
+  };
+  const config = configs[browserName];
+  if (!config) {
+    throw new Error(`Unsupported browser: ${browserName}`);
+  }
+  const candidates = [programFiles, programFilesX86, localAppData]
+    .filter(Boolean)
+    .map(root => path.join(root, ...config.installParts, config.exeName));
+
+  const exePath = candidates.find(candidate => fs.existsSync(candidate));
+  if (!exePath) {
+    throw new Error(`Could not find ${config.displayName} installation.`);
+  }
+
+  const userDataDir = path.join(localAppData ?? '', ...config.userDataParts);
+  if (!fs.existsSync(userDataDir)) {
+    throw new Error(`Could not find ${config.displayName} user data directory.`);
+  }
+
+  return { ...config, exePath, userDataDir };
+}
+
+async function waitForJson(url, timeoutMs) {
+  const started = Date.now();
+  let lastError;
+
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return await response.json();
+      }
+      lastError = new Error(`${response.status} ${response.statusText}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(250);
+  }
+
+  throw new Error(`Browser did not expose its debugging endpoint in time. ${lastError?.message ?? ''}`.trim());
+}
+
+async function waitForPageTarget(debugPort, detailUrl, timeoutMs) {
+  const started = Date.now();
+  const targetUrl = detailUrl.replace(/\/$/, '');
+
+  while (Date.now() - started < timeoutMs) {
+    const targets = await waitForJson(`http://127.0.0.1:${debugPort}/json/list`, 5000);
+    const page = targets.find(target => target.type === 'page' && target.url.replace(/\/$/, '') === targetUrl);
+    if (page?.webSocketDebuggerUrl) {
+      return page;
+    }
+    await sleep(250);
+  }
+
+  throw new Error('Browser opened, but the archive.org page target was not available in time.');
+}
+
+async function waitForWindowBr(cdp, timeoutMs) {
+  const started = Date.now();
+  let waitingForLoan = false;
+  const expression = `
+    (() => {
+      if (!window.br) return null;
+      if (window.br.protected && !window.br.options?.lendingInfo?.loanId) return "__NOT_BORROWED__";
+      return JSON.stringify({
+        reductionFactors: window.br.reductionFactors,
+        bookId: window.br.bookId,
+        bookTitle: window.br.bookTitle,
+        bookPath: window.br.bookPath,
+        server: window.br.server,
+        data: window.br.data.flat(),
+        protected: window.br.protected
+      });
+    })()
+  `;
+
+  while (Date.now() - started < timeoutMs) {
+    const result = await cdp.send('Runtime.evaluate', {
+      expression,
+      returnByValue: true,
+    });
+    const value = result.result?.value;
+
+    if (value === '__NOT_BORROWED__') {
+      if (!waitingForLoan) {
+        console.log('Waiting for an active loan in the opened browser window. Borrow the book there if it is not already borrowed.');
+        waitingForLoan = true;
+      }
+      await sleep(1000);
+      continue;
+    }
+    if (typeof value === 'string' && value.startsWith('{')) {
+      return value;
+    }
+    await sleep(500);
+  }
+
+  throw new Error('Timed out waiting for authenticated BookReader data from the browser.');
+}
+
+async function fetchResourceInBrowser(cdp, url) {
+  const expression = `
+    (async () => {
+      const response = await fetch(${JSON.stringify(url)}, { credentials: 'include' });
+      const buffer = await response.arrayBuffer();
+      const bytes = new Uint8Array(buffer);
+      let binary = '';
+      const chunkSize = 0x8000;
+      for (let i = 0; i < bytes.length; i += chunkSize) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+      }
+      return {
+        ok: response.ok,
+        status: response.status,
+        statusText: response.statusText,
+        url: response.url,
+        headers: Array.from(response.headers.entries()),
+        base64: btoa(binary),
+      };
+    })()
+  `;
+  const result = await cdp.send('Runtime.evaluate', {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+
+  if (result.exceptionDetails) {
+    throw new Error(`Browser fetch failed for ${url}`);
+  }
+
+  const value = result.result?.value;
+  if (!value) {
+    throw new Error(`Browser fetch returned no data for ${url}`);
+  }
+
+  const bytes = Buffer.from(value.base64 ?? '', 'base64');
+  return {
+    ok: value.ok,
+    status: value.status,
+    statusText: value.statusText,
+    url: value.url,
+    headers: new Map(value.headers ?? []),
+    buffer: bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  };
+}
+
+function createCdpClient(webSocketDebuggerUrl) {
+  const pending = new Map();
+  let seq = 0;
+  let ws;
+
+  return {
+    connect() {
+      return new Promise((resolve, reject) => {
+        ws = new WebSocket(webSocketDebuggerUrl);
+        ws.addEventListener('open', () => resolve());
+        ws.addEventListener('message', event => {
+          const message = JSON.parse(event.data);
+          if (!message.id) {
+            return;
+          }
+          const entry = pending.get(message.id);
+          if (!entry) {
+            return;
+          }
+          pending.delete(message.id);
+          if (message.error) {
+            entry.reject(new Error(message.error.message ?? 'CDP error'));
+          } else {
+            entry.resolve(message.result ?? {});
+          }
+        });
+        ws.addEventListener('error', event => {
+          reject(new Error(`CDP connection failed: ${event.message ?? 'unknown error'}`));
+        });
+      });
+    },
+    send(method, params = {}) {
+      const id = ++seq;
+      ws.send(JSON.stringify({ id, method, params }));
+      return new Promise((resolve, reject) => pending.set(id, { resolve, reject }));
+    },
+    close() {
+      if (ws && ws.readyState < 2) {
+        ws.close();
+      }
+    },
+  };
+}
+
+function buildCookieHeader(cookies, domain) {
+  const deduped = new Map();
+
+  for (const cookie of cookies) {
+    if (cookie.domain !== domain && cookie.domain !== `.${domain}`) {
+      continue;
+    }
+    deduped.set(cookie.name, cookie.value);
+  }
+
+  return Array.from(deduped.entries())
+    .map(([name, value]) => `${name}=${value}`)
+    .join('; ');
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function normalizeDetailUrl(input) {
+  const url = new URL(input.startsWith('http') ? input : `https://${input}`);
+  if (url.hostname !== 'archive.org') {
+    throw new Error('This local runner currently supports archive.org detail pages only.');
+  }
+  if (!url.pathname.startsWith('/details/')) {
+    throw new Error('Pass an archive.org details URL, for example https://archive.org/details/<identifier>.');
+  }
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}
+
+async function fetchText(url, headers) {
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status} ${response.statusText} for ${url}`);
+  }
+  return await response.text();
+}
+
+function extractJsiaUrl(html) {
+  const match = html.match(/"url":"(\/\/[^"]*BookReaderJSIA\.php[^"]*)"/);
+  if (!match) {
+    throw new Error('Could not find the BookReader bootstrap URL in the details page.');
+  }
+
+  let raw = match[1]
+    .replaceAll('\\/', '/')
+    .replaceAll('\\u0026', '&');
+
+  if (raw.startsWith('//')) {
+    raw = `https:${raw}`;
+  }
+  raw = raw.replace('format=jsonp', 'format=json');
+  return raw;
+}
+
+function buildDefaultName(bookId, scale, start, end, pageCount, format) {
+  let name = `${sanitizeName(bookId)}_${scale}`;
+  if (start !== 1 || end !== pageCount) {
+    name += `_${start}_${end}`;
+  }
+  return `${name}.${format}`;
+}
+
+async function createDocument(writer, format, br, pagecount) {
+  if (format === 'zip') {
+    return new ZIPDocument(writer);
+  }
+
+  const fontPath = path.join(repoRoot, 'core', 'js', 'pdf', 'font', 'data', 'Georgia.afm');
+  const fontdata = await fsp.readFile(fontPath, 'utf8');
+  const info = {
+    Title: br.bookTitle ?? br.bookId,
+    Application: 'Internet Archive Downloader CLI',
+  };
+
+  return new PDFDocument(writer, {
+    pagecount,
+    info,
+    font: 'Times-Roman',
+    fontdata,
+  });
+}
+
+async function fetchArchivePage(page, scale, headers, browserSession = null) {
+  let url = page.uri;
+  url += url.includes('?') ? '&' : '?';
+  url += `scale=${scale}&rotate=0`;
+
+  if (browserSession?.fetchResource) {
+    const browserResponse = await browserSession.fetchResource(url);
+    if (!browserResponse.ok) {
+      throw new Error(`Page fetch failed: ${browserResponse.status} ${browserResponse.statusText} for ${url}`);
+    }
+    return await ImageDecoder.decodeArchiveImage({
+      arrayBuffer: async () => browserResponse.buffer,
+      headers: {
+        get: name => browserResponse.headers.get(name.toLowerCase()) ?? browserResponse.headers.get(name) ?? null,
+      },
+      url: browserResponse.url,
+    });
+  }
+
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`Page fetch failed: ${response.status} ${response.statusText} for ${url}`);
+  }
+  return await ImageDecoder.decodeArchiveImage(response);
+}
+
+async function runPool(items, concurrency, worker) {
+  let nextIndex = 0;
+
+  async function runOne() {
+    while (true) {
+      const current = nextIndex++;
+      if (current >= items.length) {
+        return;
+      }
+      await worker(items[current]);
+    }
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, () => runOne()));
+}
+
+function sanitizeName(value) {
+  return value.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+function clampInt(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+class FileWriter {
+  constructor(filePath) {
+    this.filePath = filePath;
+    this.stream = fs.createWriteStream(filePath);
+    this.ready = Promise.resolve();
+    this.queue = Promise.resolve();
+  }
+
+  write(chunk) {
+    this.queue = this.queue.then(() => this.writeNow(chunk));
+    return this.queue;
+  }
+
+  writeNow(chunk) {
+    return new Promise((resolve, reject) => {
+      const onError = error => {
+        cleanup();
+        reject(error);
+      };
+      const onDrain = () => {
+        cleanup();
+        resolve();
+      };
+      const cleanup = () => {
+        this.stream.off('error', onError);
+        this.stream.off('drain', onDrain);
+      };
+
+      this.stream.once('error', onError);
+      const writable = this.stream.write(chunk, error => {
+        if (error) {
+          cleanup();
+          reject(error);
+        } else if (writable) {
+          cleanup();
+          resolve();
+        }
+      });
+
+      if (!writable) {
+        this.stream.once('drain', onDrain);
+      }
+    });
+  }
+
+  async close() {
+    await this.queue;
+    return new Promise((resolve, reject) => {
+      this.stream.end(error => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  async abort() {
+    this.stream.destroy();
+    await fsp.rm(this.filePath, { force: true });
+  }
+}
+
+main().catch(error => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/cli/archive-cli.mjs
+++ b/cli/archive-cli.mjs
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
+import os from 'node:os';
+import crypto from 'node:crypto';
 import process from 'node:process';
 import { spawn, spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -27,9 +29,17 @@ async function main() {
   let writer = null;
   try {
     const detailUrl = normalizeDetailUrl(options.url);
-    browserSession = getRequestedBrowserSession(options)
-      ? await loadBrowserArchiveSession(getRequestedBrowserSession(options), detailUrl, options.braveProfile ?? options.browserProfile ?? 'Default')
-      : null;
+    options.referer = detailUrl;
+    const browserName = getRequestedBrowserSession(options);
+    if (browserName) {
+      const profile = options.browserProfile ?? options.braveProfile ?? 'Default';
+      if (process.platform === 'darwin') {
+        console.log(`Reading ${browserName} cookies for archive.org from Keychain (click "Always Allow" if prompted)...`);
+        options.cookie = await readBrowserCookiesMac(browserName, profile, 'archive.org');
+      } else {
+        browserSession = await loadBrowserArchiveSession(browserName, detailUrl, profile);
+      }
+    }
     const headers = await buildHeaders(options, browserSession);
 
     console.log(`Loading ${detailUrl}`);
@@ -163,6 +173,9 @@ function parseArgs(argv) {
       case '--cookies-from-edge':
         options.cookiesFromEdge = true;
         break;
+      case '--cookies-from-chrome':
+        options.cookiesFromChrome = true;
+        break;
       case '--brave-profile':
         options.braveProfile = argv[++i];
         break;
@@ -207,6 +220,7 @@ Options:
   --cookie-file <path>  Read Cookie header value from a file
   --cookies-from-brave  Read archive.org cookies from your Brave profile
   --cookies-from-edge   Read archive.org cookies from your Edge profile
+  --cookies-from-chrome Read archive.org cookies from your Chrome profile
   --brave-profile <p>   Brave profile name, default: Default
   --browser-profile <p> Browser profile name, default: Default
   --help, -h            Show this help
@@ -227,14 +241,14 @@ async function buildHeaders(options, browserSession = null) {
   if (!cookie && options.cookieFile) {
     cookie = (await fsp.readFile(path.resolve(options.cookieFile), 'utf8')).trim();
   }
-  if (!cookie && options.cookiesFromBrave) {
-    cookie = browserSession?.cookieHeader ?? null;
-  }
-  if (!cookie && options.cookiesFromEdge) {
+  if (!cookie && (options.cookiesFromBrave || options.cookiesFromEdge || options.cookiesFromChrome)) {
     cookie = browserSession?.cookieHeader ?? null;
   }
   if (cookie) {
     headers.cookie = cookie;
+  }
+  if (options.referer) {
+    headers.referer = options.referer;
   }
 
   return headers;
@@ -253,16 +267,98 @@ function assertFullBookReaderAccess(br, pages) {
 }
 
 function getRequestedBrowserSession(options) {
-  if (options.cookiesFromBrave && options.cookiesFromEdge) {
+  const picks = [
+    options.cookiesFromBrave && 'brave',
+    options.cookiesFromEdge && 'edge',
+    options.cookiesFromChrome && 'chrome',
+  ].filter(Boolean);
+  if (picks.length > 1) {
     throw new Error('Choose only one browser cookie source.');
   }
-  if (options.cookiesFromBrave) {
-    return 'brave';
+  return picks[0] ?? null;
+}
+
+const macSafeStorageConfigs = {
+  chrome: { service: 'Chrome Safe Storage', dataDir: 'Google/Chrome' },
+  brave: { service: 'Brave Safe Storage', dataDir: 'BraveSoftware/Brave-Browser' },
+  edge: { service: 'Microsoft Edge Safe Storage', dataDir: 'Microsoft Edge' },
+};
+
+async function readBrowserCookiesMac(browserName, profileName, domain) {
+  const config = macSafeStorageConfigs[browserName];
+  if (!config) {
+    throw new Error(`Unsupported browser for cookie decryption: ${browserName}`);
   }
-  if (options.cookiesFromEdge) {
-    return 'edge';
+
+  const keychain = spawnSync('security', ['find-generic-password', '-w', '-s', config.service], { encoding: 'utf8' });
+  if (keychain.status !== 0) {
+    const detail = keychain.stderr.trim() || 'No matching keychain item found.';
+    throw new Error(`Could not read "${config.service}" from macOS Keychain. ${detail}`);
   }
-  return null;
+  const password = keychain.stdout.trim();
+  const key = crypto.pbkdf2Sync(password, 'saltysalt', 1003, 16, 'sha1');
+  const iv = Buffer.alloc(16, 0x20);
+
+  const cookiesDir = path.join(process.env.HOME ?? '', 'Library', 'Application Support', config.dataDir, profileName);
+  const cookiesPath = path.join(cookiesDir, 'Cookies');
+  if (!fs.existsSync(cookiesPath)) {
+    throw new Error(`Cookies file not found at ${cookiesPath}. Is profile "${profileName}" correct?`);
+  }
+
+  const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'iad-cookies-'));
+  try {
+    const tmpCookies = path.join(tmpDir, 'Cookies');
+    await fsp.copyFile(cookiesPath, tmpCookies);
+    for (const suffix of ['-wal', '-shm']) {
+      const sidecar = cookiesPath + suffix;
+      if (fs.existsSync(sidecar)) {
+        await fsp.copyFile(sidecar, path.join(tmpDir, 'Cookies' + suffix));
+      }
+    }
+
+    const sql = `SELECT host_key, name, value, hex(encrypted_value) AS encrypted_value FROM cookies WHERE host_key LIKE '%${domain}' OR host_key LIKE '%.${domain}'`;
+    const result = spawnSync('/usr/bin/sqlite3', ['-json', tmpCookies, sql], { encoding: 'utf8' });
+    if (result.status !== 0) {
+      throw new Error(`sqlite3 query failed: ${result.stderr.trim()}`);
+    }
+    const rows = result.stdout.trim() ? JSON.parse(result.stdout) : [];
+
+    const cookies = new Map();
+    for (const row of rows) {
+      let value = row.value;
+      if (!value && row.encrypted_value) {
+        const blob = Buffer.from(row.encrypted_value, 'hex');
+        const prefix = blob.subarray(0, 3).toString('utf8');
+        if (prefix !== 'v10' && prefix !== 'v11') {
+          continue;
+        }
+        try {
+          const decipher = crypto.createDecipheriv('aes-128-cbc', key, iv);
+          let plain = Buffer.concat([decipher.update(blob.subarray(3)), decipher.final()]);
+          if (plain.length >= 32) {
+            const expected = crypto.createHash('sha256').update(row.host_key).digest();
+            if (plain.subarray(0, 32).equals(expected)) {
+              plain = plain.subarray(32);
+            }
+          }
+          value = plain.toString('utf8');
+        } catch (_) {
+          continue;
+        }
+      }
+      if (value !== undefined && value !== null && value !== '') {
+        cookies.set(row.name, value);
+      }
+    }
+
+    if (cookies.size === 0) {
+      throw new Error(`No ${domain} cookies found in ${browserName} profile "${profileName}". Open https://${domain} in ${browserName} and log in first.`);
+    }
+
+    return Array.from(cookies.entries()).map(([n, v]) => `${n}=${v}`).join('; ');
+  } finally {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  }
 }
 
 async function loadBrowserArchiveSession(browserName, detailUrl, profileName) {
@@ -334,54 +430,87 @@ async function loadBrowserArchiveSession(browserName, detailUrl, profileName) {
 }
 
 function isProcessRunning(imageName) {
-  const result = spawnSync('tasklist', ['/FI', `IMAGENAME eq ${imageName}`], {
-    encoding: 'utf8',
-    windowsHide: true,
-  });
-  return result.status === 0 && result.stdout.toLowerCase().includes(imageName.toLowerCase());
+  if (process.platform === 'win32') {
+    const result = spawnSync('tasklist', ['/FI', `IMAGENAME eq ${imageName}`], {
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+    return result.status === 0 && result.stdout.toLowerCase().includes(imageName.toLowerCase());
+  }
+  const result = spawnSync('pgrep', ['-x', imageName], { encoding: 'utf8' });
+  return result.status === 0 && result.stdout.trim().length > 0;
 }
 
 function findBrowserInstall(browserName) {
-  const localAppData = process.env.LOCALAPPDATA;
-  const programFiles = process.env['PROGRAMFILES'];
-  const programFilesX86 = process.env['PROGRAMFILES(X86)'];
-  const configs = {
-    brave: {
-      displayName: 'Brave',
-      processName: 'brave.exe',
-      exeName: 'brave.exe',
-      debugPort: 9223,
-      installParts: ['BraveSoftware', 'Brave-Browser', 'Application'],
-      userDataParts: ['BraveSoftware', 'Brave-Browser', 'User Data'],
-    },
-    edge: {
-      displayName: 'Edge',
-      processName: 'msedge.exe',
-      exeName: 'msedge.exe',
-      debugPort: 9224,
-      installParts: ['Microsoft', 'Edge', 'Application'],
-      userDataParts: ['Microsoft', 'Edge', 'User Data'],
-    },
-  };
+  const configs = process.platform === 'darwin' ? macBrowserConfigs() : windowsBrowserConfigs();
   const config = configs[browserName];
   if (!config) {
     throw new Error(`Unsupported browser: ${browserName}`);
   }
-  const candidates = [programFiles, programFilesX86, localAppData]
-    .filter(Boolean)
-    .map(root => path.join(root, ...config.installParts, config.exeName));
 
-  const exePath = candidates.find(candidate => fs.existsSync(candidate));
+  const exePath = config.exeCandidates.find(candidate => fs.existsSync(candidate));
   if (!exePath) {
     throw new Error(`Could not find ${config.displayName} installation.`);
   }
-
-  const userDataDir = path.join(localAppData ?? '', ...config.userDataParts);
-  if (!fs.existsSync(userDataDir)) {
-    throw new Error(`Could not find ${config.displayName} user data directory.`);
+  if (!fs.existsSync(config.userDataDir)) {
+    throw new Error(`Could not find ${config.displayName} user data directory at ${config.userDataDir}.`);
   }
 
-  return { ...config, exePath, userDataDir };
+  return { ...config, exePath };
+}
+
+function windowsBrowserConfigs() {
+  const localAppData = process.env.LOCALAPPDATA;
+  const programFiles = process.env['PROGRAMFILES'];
+  const programFilesX86 = process.env['PROGRAMFILES(X86)'];
+  const roots = [programFiles, programFilesX86, localAppData].filter(Boolean);
+
+  const make = (displayName, processName, exeName, installParts, userDataParts, debugPort) => ({
+    displayName,
+    processName,
+    debugPort,
+    exeCandidates: roots.map(root => path.join(root, ...installParts, exeName)),
+    userDataDir: path.join(localAppData ?? '', ...userDataParts),
+  });
+
+  return {
+    brave: make('Brave', 'brave.exe', 'brave.exe',
+      ['BraveSoftware', 'Brave-Browser', 'Application'],
+      ['BraveSoftware', 'Brave-Browser', 'User Data'], 9223),
+    edge: make('Edge', 'msedge.exe', 'msedge.exe',
+      ['Microsoft', 'Edge', 'Application'],
+      ['Microsoft', 'Edge', 'User Data'], 9224),
+    chrome: make('Chrome', 'chrome.exe', 'chrome.exe',
+      ['Google', 'Chrome', 'Application'],
+      ['Google', 'Chrome', 'User Data'], 9222),
+  };
+}
+
+function macBrowserConfigs() {
+  const appSupport = path.join(process.env.HOME ?? '', 'Library', 'Application Support');
+  return {
+    brave: {
+      displayName: 'Brave',
+      processName: 'Brave Browser',
+      debugPort: 9223,
+      exeCandidates: ['/Applications/Brave Browser.app/Contents/MacOS/Brave Browser'],
+      userDataDir: path.join(appSupport, 'BraveSoftware', 'Brave-Browser'),
+    },
+    edge: {
+      displayName: 'Edge',
+      processName: 'Microsoft Edge',
+      debugPort: 9224,
+      exeCandidates: ['/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'],
+      userDataDir: path.join(appSupport, 'Microsoft Edge'),
+    },
+    chrome: {
+      displayName: 'Chrome',
+      processName: 'Google Chrome',
+      debugPort: 9222,
+      exeCandidates: ['/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'],
+      userDataDir: path.join(appSupport, 'Google', 'Chrome'),
+    },
+  };
 }
 
 async function waitForJson(url, timeoutMs) {
@@ -644,25 +773,38 @@ async function fetchArchivePage(page, scale, headers, browserSession = null) {
   url += url.includes('?') ? '&' : '?';
   url += `scale=${scale}&rotate=0`;
 
-  if (browserSession?.fetchResource) {
-    const browserResponse = await browserSession.fetchResource(url);
-    if (!browserResponse.ok) {
-      throw new Error(`Page fetch failed: ${browserResponse.status} ${browserResponse.statusText} for ${url}`);
-    }
-    return await ImageDecoder.decodeArchiveImage({
-      arrayBuffer: async () => browserResponse.buffer,
-      headers: {
-        get: name => browserResponse.headers.get(name.toLowerCase()) ?? browserResponse.headers.get(name) ?? null,
-      },
-      url: browserResponse.url,
-    });
-  }
+  const maxAttempts = 5;
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      if (browserSession?.fetchResource) {
+        const browserResponse = await browserSession.fetchResource(url);
+        if (!browserResponse.ok) {
+          throw new Error(`Page fetch failed: ${browserResponse.status} ${browserResponse.statusText} for ${url}`);
+        }
+        return await ImageDecoder.decodeArchiveImage({
+          arrayBuffer: async () => browserResponse.buffer,
+          headers: {
+            get: name => browserResponse.headers.get(name.toLowerCase()) ?? browserResponse.headers.get(name) ?? null,
+          },
+          url: browserResponse.url,
+        });
+      }
 
-  const response = await fetch(url, { headers });
-  if (!response.ok) {
-    throw new Error(`Page fetch failed: ${response.status} ${response.statusText} for ${url}`);
+      const response = await fetch(url, { headers });
+      if (!response.ok) {
+        throw new Error(`Page fetch failed: ${response.status} ${response.statusText} for ${url}`);
+      }
+      return await ImageDecoder.decodeArchiveImage(response);
+    } catch (error) {
+      lastError = error;
+      if (attempt === maxAttempts) break;
+      const delay = Math.min(1000 * 2 ** (attempt - 1), 8000);
+      console.log(`  retry ${attempt}/${maxAttempts - 1} for ${url} after ${delay}ms (${error.message})`);
+      await sleep(delay);
+    }
   }
-  return await ImageDecoder.decodeArchiveImage(response);
+  throw lastError;
 }
 
 async function runPool(items, concurrency, worker) {

--- a/iad.cmd
+++ b/iad.cmd
@@ -1,0 +1,2 @@
+@echo off
+node "%~dp0cli\archive-cli.mjs" %*

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "internet-archive-downloader-local",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "iad": "./cli/archive-cli.mjs"
+  }
+}


### PR DESCRIPTION
Builds on top of #120 (RelevantJesse's local CLI). Since that PR is not yet merged, this branch includes Jesse's commit as well — if/when #120 lands, the diff here will narrow to just the macOS additions.

Changes:
- Decrypt Brave / Edge / Chrome cookies from macOS Keychain (Safe Storage + sqlite3 — no headless browser needed on macOS)
- Add `--cookies-from-chrome` flag
- Set `Referer` header to the detail URL
- README: macOS/Linux invocation example, note Node.js 22+ requirement